### PR TITLE
Bump Books to version 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,8 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "1"
+Books = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,17 +1,16 @@
 ---
 title: Embrace Uncertainty
 subtitle: Fitting Mixed-Effects Models with Julia
-book: true
-author: "Phillip Alday, Dave Kleinschmidt, Reinhold Kliegl, and Douglas Bates"
+author:
+  - Phillip Alday
+  - Dave Kleinschmidt
+  - Reinhold Kliegl
+  - Douglas Bates
 html-license: <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>
 pdf-footer: "\\textbf{DRAFT} - See \\url{https://... } for the latest version."
-tex-license: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
+tex-license: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 lang: en-US
 tags: [JuliaLang, Linear Mixed Models]
 repo: https://github.com/JuliaMixedModels
-secPrefix: Section
-figPrefix: Figure
-tblPrefix: Table
-titlepage: true
 bibliography: pandoc/EmbUnc.bib
 ---


### PR DESCRIPTION
I've released Books.jl version 1. The PDF output is now much nicer and publication ready (if I may say so). For example, see the screenshots in https://github.com/rikhuijzer/Books.jl/pull/219. A preview is also available at https://rikhuijzer.github.io/Books.jl/books.pdf.

This PR should fix all breaking changes that I made between version `0.7` and `1.1`.

For examples of how to configure the titlepage see the `template.tex`. All variables set in `metadata.yml` are passed to the `template.tex` file and Pandoc will embed the variables.