### PR TITLE
Drop ProgressMeter dep, add code block labels

### DIFF
--- a/aGHQ.qmd
+++ b/aGHQ.qmd
@@ -128,9 +128,11 @@ Load the packages to be used
 ```{julia}
 #| code-fold: true
 #| output: false
+#| label: packagesA03
 using AlgebraOfGraphics
 using BenchmarkTools
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using EmbraceUncertainty: dataset
 using FreqTables
 using LinearAlgebra
@@ -138,14 +140,17 @@ using MixedModels
 using MixedModelsMakie
 using NLopt
 using PooledArrays
-using ProgressMeter
 using StatsAPI
+```
 
-# showcompact prints a vector compactly
-showcompact(x) = show(IOContext(stdout, :compact => true), x)
+and define some constants
 
-ProgressMeter.ijulia_behavior(:clear)
-CairoMakie.activate!(; type="svg")
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constantsA03
+@isdefined(contrasts) || const contrasts = Dict{Symbol,Any}()
+@isdefined(progress) || const progress = false
 ```
 
 ## Generalized linear models for binary data {#sec-BernoulliGLM}
@@ -233,18 +238,16 @@ We illustrate some of these computations using only the fixed-effects specificat
 ```{julia}
 #| code-fold: show
 #| output: false
+#| label: com05
 contra = let tbl = dataset(:contra)
   Table(tbl; ch=tbl.livch .≠ "0")
 end
-contrasts = Dict{Symbol,Any}(
-  :urban => HelmertCoding(),
-  :ch => HelmertCoding(),
-  :dist => Grouping(),
-)
+contrasts[:urban] = HelmertCoding()
+contrasts[:ch] = HelmertCoding()
 com05 =
   let f = @formula use ~
       1 + urban + ch * age + age & age + (1 | dist & urban)
-    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ=9)
+    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ=9, progress)
   end
 ```
 
@@ -252,7 +255,6 @@ Extract the fixed-effects model matrix, $\bbX$, and initialize the coefficient v
 
 ```{julia}
 βm05 = copy(com05.β)
-showcompact(βm05)   # showcompact is defined in the first code block
 ```
 
 As stated above, the `meanunitdev` function can be applied to the vectors, ${\mathbf{y}}$ and ${\bbeta}$, via dot-vectorization to produce a `Vector{NamedTuple}`, which is the typical form of a row-table.
@@ -342,7 +344,6 @@ Create such a struct from `X` and `y` for model `com05`.
 ```{julia}
 com05fe = BernoulliGLM(com05.X, com05.y)
 β₀ = copy(com05fe.β)          # keep a copy of the initial values
-showcompact(β₀)
 ```
 
 These initial values of $\bbbeta$ are from a least squares fit of $\bby$, converted from `{0,1}` coding to `{-1,1}` coding, on the model matrix, $\bbX$.
@@ -946,8 +947,12 @@ fit!(m);
 
 ```{julia}
 #| code-fold: true
-println("Converged to θ = ", first(m.θβ), " and β =")
-showcompact(view(m.θβ, 2:lastindex(m.θβ)))
+println(
+  "Converged to θ = ",
+  first(m.θβ),
+  " and β =",
+  view(m.θβ, 2:lastindex(m.θβ)),
+)
 ```
 
 These estimates differ somewhat from those for model `com05`.
@@ -960,8 +965,8 @@ println(
   ", fmin = ",
   deviance(com05),
   ", and β =",
+  com05.β
 )
-showcompact(com05.β)
 ```
 
 The discrepancy in the results is because the `com05` results are based on a more accurate approximation to the integral called *adaptive Gauss-Hermite Quadrature*, which is discussed in @sec-aGHQ.
@@ -1081,11 +1086,11 @@ sym5 = SymTridiagonal(zeros(5), sqrt.(1:4))
 
 ```{julia}
 ev = eigen(sym5);
-showcompact(ev.values)
+ev.values
 ```
 
 ```{julia}
-showcompact(abs2.(ev.vectors[1, :]))
+abs2.(ev.vectors[1, :])
 ```
 
 A function of `k` to evaluate the abscissae and weights is
@@ -1404,8 +1409,9 @@ end
 ```
 
 ```{julia}
+#| warning: false
 fitGHQ!(m)
-showcompact(m.θβ)
+m.θβ
 ```
 
 *This page was rendered from git revision {{< git-rev short=true >}}.*

--- a/glmmbernoulli.qmd
+++ b/glmmbernoulli.qmd
@@ -22,23 +22,28 @@ Attach the packages to be used in this chapter
 ```{julia}
 #| code-fold: true
 #| output: false
+#| label: packages06
 using AlgebraOfGraphics
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using DataFrames         # only used for `describe`
 using EmbraceUncertainty: dataset
 using FreqTables
 using MixedModels
 using MixedModelsMakie
-using ProgressMeter
 using StatsBase
 using StatsModels
+```
 
-if !@isdefined(contrasts)
-  const contrasts = Dict{Symbol,Any}()
-end
-const nAGQ = 9
-CairoMakie.activate!(; type="svg")
-ProgressMeter.ijulia_behavior(:clear)
+and defined some constants, if not already defined.
+
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constants06
+@isdefined(contrasts) || const contrasts = Dict{Symbol,Any}()
+@isdefined(nAGQ) || const nAGQ = 9
+@isdefined(progress) || const progress = false
 ```
 
 In this chapter we consider mixed-effects models for data sets in which the response is *binary*, representing  yes/no or true/false or correct/incorrect responses.
@@ -135,12 +140,11 @@ Establishing the contrasts and fitting a preliminary model with random effects f
 ```{julia}
 contrasts[:livch] = EffectsCoding(; base="0")
 contrasts[:urban] = HelmertCoding()
-contrasts[:dist] = Grouping()
 
 com01 = let
   f = @formula use ~
     1 + livch + (age + abs2(age)) * urban + (1 | dist)
-  fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ)
+  fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ, progress)
 end
 ```
 
@@ -191,7 +195,7 @@ we fit a reduced model.
 ```{julia}
 com02 =
   let f = @formula use ~ 1 + ch + age * age * urban + (1 | dist)
-    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ)
+    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ, progress)
   end
 ```
 
@@ -208,7 +212,7 @@ Apparently neither the second-order interaction `age & urban` nor the third-orde
 ```{julia}
 com03 =
   let f = @formula use ~ 1 + urban + ch + age * age + (1 | dist)
-    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ)
+    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ, progress)
   end
 ```
 
@@ -247,7 +251,7 @@ Incorporating an interaction of `age` and `ch` allows for such a shift.
 com04 =
   let f =
       @formula use ~ 1 + urban + ch * age + abs2(age) + (1 | dist)
-    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ)
+    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ, progress)
   end
 ```
 
@@ -265,7 +269,7 @@ A series of such model fits led to a model with random effects for the combinati
 com05 =
   let f = @formula use ~
       1 + urban + ch * age + abs2(age) + (1 | dist & urban)
-    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ)
+    fit(MixedModel, f, contra, Bernoulli(); contrasts, nAGQ, progress)
   end
 ```
 

--- a/intro.qmd
+++ b/intro.qmd
@@ -102,6 +102,7 @@ To access these data within `Julia` we must first attach this package, and other
 ```{julia}
 #| code-fold: show
 #| output: false
+#| label: packages01
 using AlgebraOfGraphics # high-level graphics
 using CairoMakie        # graphics back-end
 using DataFrameMacros   # elegant DataFrame manipulation
@@ -110,14 +111,11 @@ using Markdown          # utilities for generating markdown text
 using MixedModels       # fit and examine mixed-effects models
 using MixedModelsMakie  # graphics for mixed-effects models
 using Printf            # formatted printing
-using ProgressMeter     # progress of optimizer iterations
 using Random            # random number generation
 using StatsBase         # basic statistical summaries
 
-using EmbraceUncertainty: dataset # `dataset` means this one
-
-CairoMakie.activate!(; type="svg")    # Scalable Vector Graphics
-ProgressMeter.ijulia_behavior(:clear) # suppress progress output
+CairoMakie.activate!(; type="svg") # set Scalable Vector Graphics output
+using EmbraceUncertainty: dataset  # `dataset` means this one
 ```
 
 A package must be attached before any of the data sets or functions in the package can be used.
@@ -144,6 +142,7 @@ in examples and in tests of the `MixedModels` package.
 :::
 
 ```{julia}
+#| label: dyestuff_data
 dyestuff = dataset(:dyestuff)
 ```
 
@@ -154,12 +153,14 @@ This particular table, read from an `Arrow` file, will be read-only.
 Often it is convenient to convert the read-only table form to a `DataFrame` to be able to use the full power of the [DataFrames](https://github.com/JuliaData/DataFrames.jl) package.
 
 ```{julia}
+#| label: dyestuff_dataframe
 dyestuff = DataFrame(dyestuff)
 ```
 
 The `describe` method for a `DataFrame` provides a concise description of the structure of the data,
 
 ```{julia}
+#| label: describe_dyestuff
 describe(dyestuff)
 ```
 
@@ -196,6 +197,7 @@ last(dyestuff, 7)
 or we could tabulate the data using `groupby` and `combine` from [DataFrames](https://github.com/JuliaData/DataFrames.jl).
 
 ```{julia}
+#| label: dyestuff_summary
 combine(groupby(dyestuff, :batch), :yield => mean, nrow => :n)
 ```
 
@@ -256,10 +258,12 @@ The data are simulated data presented in @box73:_bayes_infer_statis_analy [, Tab
 The structure and summary
 
 ```{julia}
+#| label: dyestuff2
 dyestuff2 = dataset(:dyestuff2)
 ```
 
 ```{julia}
+#| label: dyestuff2_dataframe
 dyestuff2 = DataFrame(dyestuff2)
 describe(dyestuff2)
 ```
@@ -306,9 +310,9 @@ We will explain the structure of the formula after we have considered an example
 We fit a model to the data allowing for an overall level of the `yield` and for an additive random effect for each level of `batch`.
 
 ```{julia}
-dsm01 = let
-  form = @formula(yield ~ 1 + (1 | batch))
-  fit(MixedModel, form, dyestuff)
+#| label: dsm01
+dsm01 = let f = @formula(yield ~ 1 + (1 | batch))
+  fit(MixedModel, f, dyestuff; progress=false)
 end
 ```
 
@@ -381,9 +385,9 @@ An alternative measure of precision of the estimate - a coverage interval based 
 Fitting a similar model to the `dyestuff2` data produces an estimate $\widehat{\sigma}_1=0$.
 
 ```{julia}
-dsm02 = let
-  form = @formula(yield ~ 1 + (1 | batch))
-  fit(MixedModel, form, dyestuff2)
+#| label: dsm02
+dsm02 = let f = @formula(yield ~ 1 + (1 | batch))
+  fit(MixedModel, f, dyestuff2; progress=false)
 end
 println(dsm02)
 ```
@@ -564,10 +568,10 @@ The object returned by a call to `parametricbootstrap` has a somewhat complex in
 To examine the distribution of the parameter estimates we extract a table of all the estimated parameters and convert it to a `DataFrame`.
 
 ```{julia}
+#| label: dsm01samp
 #| warning: false
-const hide_progress = true # hide the progress bar when sampling
 Random.seed!(4321234)      # random number generator
-dsm01samp = parametricbootstrap(10_000, dsm01; hide_progress)
+dsm01samp = parametricbootstrap(10_000, dsm01; progress=false)
 dsm01pars = DataFrame(dsm01samp.allpars)
 first(dsm01pars, 7)
 ```
@@ -690,6 +694,7 @@ Nearly 1000 of the 10,000 bootstrap fits are "singular" in that one (or more) of
 For this model the only way singularity can occur is for $\sigma_1$ to be zero.
 
 ```{julia}
+#| label: dsm01samp_singular
 count(issingular(dsm01samp))
 ```
 
@@ -745,11 +750,13 @@ The interval on the residual standard deviation, $\sigma$, is reasonable, given 
 The optional argument, `thin=1`, in a call to `fit` causes all the values of $\boldsymbol\theta$ and the corresponding value of objective from the iterative optimization to be stored in the `optsum` property.
 
 ```{julia}
+#| label: dsm01trace
 dsm01trace = fit(
   MixedModel,
   @formula(yield ~ 1 + (1 | batch)),
   dyestuff;
   thin=1,
+  progress=false,
 )
 DataFrame(dsm01trace.optsum.fitlog)
 ```
@@ -877,6 +884,7 @@ dsm01 = fit(
   @formula(yield ~ 1 + (1 | batch)),
   dyestuff;
   contrasts=contrasts,
+  progress=false,
 )
 ```
 
@@ -890,12 +898,15 @@ dsm01 = fit(
   @formula(yield ~ 1 + (1 | batch)),
   dyestuff;
   contrasts,
+  progress=false
 )
 ```
 
 That is, if the name of the object to be passed as a named argument is the same as the name of the argument, like `contrasts=contrasts`, then the name does not need to be repeated.
 Note that the comma after the positional arguments must be changed to a semicolon in this convention.
 This is necessary because it indicates that arguments following the semicolon are named arguments, not positional.
+
+Similarly, we could (and will, in later chapters), bind the name `progress` to `false` in the Main environment and use `progress` as a named argument instead of `progress=false` to suppress output of the progress of the iterations.
 
 Another convention we will use is assigning the formula separately from the call to `fit` as part of a `let` block.
 Often the formula can become rather long, sometimes needing multiple lines in the call, and it becomes difficult to keep track of the other arguments.
@@ -910,7 +921,7 @@ Thus `dsm01` can be assigned as
 #| code-fold: false
 #| eval: false
 dsm01 = let f = @formula(yield ~ 1 + (1 | batch))
-  fit(MixedModel, f, dyestuff; contrasts)
+  fit(MixedModel, f, dyestuff; contrasts, progress=false)
 end
 ```
 

--- a/largescaledesigned.qmd
+++ b/largescaledesigned.qmd
@@ -4,14 +4,16 @@ jupyter: julia-1.10
 
 # A large-scale designed experiment {#sec-largescaledesigned}
 
-Load the packages to be used.
+Load the packages to be used
 
 ```{julia}
 #| code-fold: true
 #| output: false
+#| label: packages04
 using AlgebraOfGraphics
 using Arrow
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using Chain
 using DataFrameMacros
 using DataFrames
@@ -20,14 +22,17 @@ using EmbraceUncertainty: dataset
 using LinearAlgebra
 using MixedModels
 using MixedModelsMakie
-using ProgressMeter
 using StandardizedPredictors
 using StatsBase
+```
 
-const contrasts =
-  Dict{Symbol,Any}(:item => Grouping(), :subj => Grouping())
-CairoMakie.activate!(; type="svg")
-ProgressMeter.ijulia_behavior(:clear)
+and define some constants, if not already defined.
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constants04
+@isdefined(contrasts) || const contrasts = Dict{Symbol, Any}()
+@isdefined(progress) || const progress = false
 ```
 
 As with many techniques in data science, the place where "the rubber meets the road", as they say in the automotive industry, for mixed-effects models is when working on large-scale studies.
@@ -465,7 +470,7 @@ and fit a first model with simple, scalar, random effects for `subj` and `item`.
 ```{julia}
 elm01 = let f = @formula 1000/rt ~
     1 + isword * wrdlen + (1 | item) + (1 | subj)
-  fit(MixedModel, f, pruned; contrasts)
+  fit(MixedModel, f, pruned; contrasts, progress)
 end
 ```
 
@@ -481,7 +486,7 @@ If we restrict to only those subjects with 80% accuracy or greater the model bec
 elm02 = let f = @formula 1000 / rt ~
     1 + isword * wrdlen + (1 | item) + (1 | subj)
   dat = filter(:spropacc => >(0.8), pruned)
-  fit(MixedModel, f, dat; contrasts)
+  fit(MixedModel, f, dat; contrasts, progress)
 end
 ```
 

--- a/largescaleobserved.qmd
+++ b/largescaleobserved.qmd
@@ -6,28 +6,36 @@ jupyter: julia-1.10
 
 # A large-scale observational study {#sec-largescaleobserved}
 
-Load the packages to be used.
+Load the packages to be used,
 
 ```{julia}
 #| code-fold: true
 #| output: false
+#| label: packages05
 using AlgebraOfGraphics
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using CategoricalArrays
 using DataFrames
 using EmbraceUncertainty: dataset
 using GLM                  # for the lm function
 using MixedModels
 using MixedModelsMakie
-using ProgressMeter
 using SparseArrays         # for the nnz function
 using Statistics           # for the mean function
 using TypedTables
+```
 
+and define some constants and a utility function
+
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constants05
 optsumdir(paths::AbstractString...) =
   joinpath(@__DIR__, "optsums", paths...)
-CairoMakie.activate!(; type="svg")
-ProgressMeter.ijulia_behavior(:clear)
+@isdefined(contrasts) || const contrasts = Dict{Symbol, Any}()
+@isdefined(progress) || const progress=false
 ```
 
 In the previous chapter we explored and fit models to data from a large-scale designed experiment.

--- a/longitudinal.qmd
+++ b/longitudinal.qmd
@@ -23,32 +23,33 @@ jupyter: julia-1.10
 \newcommand\mcB{{\mathcal{B}}}
 \newcommand\mcY{{\mathcal{Y}}}
 
-Load the packages to be used.
+Load the packages to be used,
 
 ```{julia}
 #| code-fold: true
 #| output: false
-
+#| label: packages03
 using AlgebraOfGraphics
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using DataFrameMacros
 using DataFrames
 using EmbraceUncertainty: dataset
 using LinearAlgebra
 using MixedModels
 using MixedModelsMakie
-using ProgressMeter
 using Random
 using RCall
 using StandardizedPredictors
+```
 
-#using CairoMakie: scatter! # PA I have no idea why this is failing to resolve later since this exported
-
-if !isdefined(Main, :contrasts)
-  const contrasts = Dict{Symbol,Any}()
-end
-CairoMakie.activate!(; type="svg")
-ProgressMeter.ijulia_behavior(:clear)
+and declare some constants, if not already defined.
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constants03
+@isdefined(contrasts) || const contrasts = Dict{Symbol,Any}()
+@isdefined(progress) || const progress = false
 ```
 
 Longitudinal data consist of repeated measurements on the same subject, or some other observational unit, taken over time.
@@ -129,9 +130,8 @@ Similarly, `S06` and `S11` have longer initial bone lengths and a low growth rat
 Although it seems that there isn't a strong correlation between initial bone length and growth rate in these data, a model with an overall linear trend and possibly correlated random effects for intercept and slope by subject estimates a strong negative correlation (-0.97) between these random effects.
 
 ```{julia}
-contrasts[:Subj] = Grouping()
 egm01 = let f = @formula resp ~ 1 + time + (1 + time | Subj)
-  fit(MixedModel, f, egdf; contrasts)
+  fit(MixedModel, f, egdf; contrasts, progress)
 end
 println(egm01)
 ```
@@ -176,7 +176,7 @@ A model with `time` centered at 8 years of age can be fit as
 ```{julia}
 contrasts[:time] = Center(8)
 egm02 = let f = @formula resp ~ 1 + time + (1 + time | Subj)
-  fit(MixedModel, f, egdf; contrasts)
+  fit(MixedModel, f, egdf; contrasts, progress)
 end
 println(egm02)
 ```
@@ -199,7 +199,7 @@ A third option is to center the `time` covariate at the mean of the original `ti
 ```{julia}
 contrasts[:time] = Center()
 egm03 = let f = @formula resp ~ 1 + time + (1 + time | Subj)
-  fit(MixedModel, f, egdf; contrasts)
+  fit(MixedModel, f, egdf; contrasts, progress)
 end
 println(egm03)
 ```
@@ -251,7 +251,7 @@ egm04 =
   let f = @formula resp ~
       1 + ctime + ctime^2 + (1 + ctime + ctime^2 | Subj)
     dat = @transform(egdf, :ctime = :time - 8.75)
-    fit(MixedModel, f, dat; contrasts)
+    fit(MixedModel, f, dat; contrasts, progress)
   end
 println(egm04)
 ```
@@ -423,7 +423,7 @@ delete!(contrasts, :time)
 bxm01 =
   let f = @formula resp ~
       (1 + time + time^2) * Group + (1 + time + time^2 | Subj)
-    fit(MixedModel, f, bxdf; contrasts)
+    fit(MixedModel, f, bxdf; contrasts, progress)
   end
 ```
 
@@ -433,7 +433,7 @@ but we expect that a model without the main effect for `Group`,
 bxm02 =
   let f = @formula resp ~
       1 + (time + time^2) & Group + (1 + time + time^2 | Subj)
-    fit(MixedModel, f, bxdf; contrasts)
+    fit(MixedModel, f, bxdf; contrasts, progress)
   end
 ```
 
@@ -466,7 +466,7 @@ It would indicate that the groups are initially homogeneous both in weight and g
 bxm03 =
   let f = @formula resp ~
       1 + time + time^2 & Group + (1 + time + time^2 | Subj)
-    fit(MixedModel, f, bxdf; contrasts)
+    fit(MixedModel, f, bxdf; contrasts, progress)
   end
 ```
 
@@ -577,7 +577,7 @@ bxm03samp = parametricbootstrap(
   Xoshiro(8642468),
   10_000,
   bxm03;
-  hide_progress=true,
+  progress=false,
 )
 bxm03pars = DataFrame(bxm03samp.allpars)
 DataFrame(shortestcovint(bxm03samp))
@@ -631,7 +631,7 @@ Because of these high correlations, trying to deal with the degenerate random ef
 bxm04 =
   let f =
       @formula resp ~ 1 + time + time^2 & Group + (1 + time | Subj)
-    fit(MixedModel, f, bxdf; contrasts)
+    fit(MixedModel, f, bxdf; contrasts, progress)
   end
 ```
 
@@ -649,7 +649,7 @@ bxm05 =
       time^2 & Group +
       (1 + time | Subj) +
       (0 + time^2 | Subj)
-    fit(MixedModel, f, bxdf; contrasts)
+    fit(MixedModel, f, bxdf; contrasts, progress)
   end
 ```
 

--- a/multiple.qmd
+++ b/multiple.qmd
@@ -29,32 +29,29 @@ Attach the packages to be used in this chapter
 ```{julia}
 #| code-fold: true
 #| output: false
-const hide_progress = true
-
+#| label: packages02
 using AlgebraOfGraphics
 using CairoMakie
+CairoMakie.activate!(; type="svg")
 using CategoricalArrays
 using DataFrameMacros
 using DataFrames
 using EmbraceUncertainty: dataset
 using MixedModels
 using MixedModelsMakie
-using ProgressMeter
 using Random
 using RCall
 using StatsBase
+```
 
-const contrasts = Dict{Symbol,Any}(
-  :sample => Grouping(),
-  :plate => Grouping(),
-  :s => Grouping(),
-  :batch => Grouping(),
-  :d => Grouping(),
-  :dept => Grouping(),
-)
+and define some constants, if not already defined,
 
-ProgressMeter.ijulia_behavior(:clear)
-CairoMakie.activate!(; type="svg")
+```{julia}
+#| code-fold: true
+#| output: false
+#| label: constants02
+@isdefined(contrasts) || const contrasts = Dict{Symbol,Any}()
+@isdefined(progress) || const progress = false
 ```
 
 The mixed models considered in the previous chapter had only one random-effects term, which was a simple, scalar random-effects term, and a single fixed-effects coefficient.
@@ -184,7 +181,7 @@ A model incorporating random effects for both the `plate` and the `sample` is st
 
 ```{julia}
 pnm01 = let f = @formula diameter ~ 1 + (1 | plate) + (1 | sample)
-  fit(MixedModel, f, penicillin; contrasts)
+  fit(MixedModel, f, penicillin; contrasts, progress)
 end
 ```
 
@@ -254,7 +251,7 @@ A parametric bootstrap sample of the parameter estimates
 ```{julia}
 #| code-fold: true
 bsrng = Random.seed!(9876789)
-pnm01samp = parametricbootstrap(bsrng, 10_000, pnm01; hide_progress)
+pnm01samp = parametricbootstrap(bsrng, 10_000, pnm01; progress)
 pnm01pars = DataFrame(pnm01samp.allpars);
 ```
 
@@ -416,7 +413,7 @@ We include random-effects terms for each factor, as in
 
 ```{julia}
 psm01 = let f = @formula strength ~ 1 + (1 | sample) + (1 | batch)
-  fit(MixedModel, f, pastes; contrasts)
+  fit(MixedModel, f, pastes; contrasts, progress)
 end
 ```
 
@@ -464,7 +461,7 @@ Furthermore, kernel density estimates from a parametric bootstrap sample of the 
 
 ```{julia}
 Random.seed!(4567654)
-psm01samp = parametricbootstrap(10_000, psm01; hide_progress)
+psm01samp = parametricbootstrap(10_000, psm01; progress)
 psm01pars = DataFrame(psm01samp.allpars);
 ```
 
@@ -512,7 +509,7 @@ The restricted model fit
 
 ```{julia}
 psm02 = let f = @formula strength ~ 1 + (1 | sample)
-  fit(MixedModel, f, pastes; contrasts)
+  fit(MixedModel, f, pastes; contrasts, progress)
 end
 ```
 
@@ -545,7 +542,7 @@ psm02samp = parametricbootstrap(
   Random.seed!(9753579),
   10_000,
   psm02;
-  hide_progress,
+  progress,
 )
 DataFrame(shortestcovint(psm02samp))
 ```
@@ -607,7 +604,7 @@ At this point we will fit models that have random effects for student, instructo
 
 ```{julia}
 iem01 = let f = @formula y ~ 1 + (1 | s) + (1 | d) + (1 | dept)
-  fit(MixedModel, f, insteval; contrasts)
+  fit(MixedModel, f, insteval; contrasts, progress)
 end
 ```
 
@@ -627,7 +624,7 @@ However, the p-value for the LRT of $H_0:\sigma_3=0$ versus $H_a:\sigma_3>0$
 
 ```{julia}
 iem02 = let f = @formula y ~ 1 + (1 | s) + (1 | d)
-  fit(MixedModel, f, insteval; contrasts)
+  fit(MixedModel, f, insteval; contrasts, progress)
 end
 MixedModels.likelihoodratiotest(iem02, iem01)
 ```
@@ -669,7 +666,7 @@ The simplest approach is to add `service` to the fixed-effects specification
 ```{julia}
 iem03 =
   let f = @formula y ~ 1 + service + (1 | s) + (1 | d) + (1 | dept)
-    fit(MixedModel, f, insteval; contrasts)
+    fit(MixedModel, f, insteval; contrasts, progress)
   end
 ```
 


### PR DESCRIPTION
- drop dependency on `ProgressMeter` package
- use explicit `progress=false` argument on model fits, bootstrap calls in ch. 1
- use `@isdefined(progress) || const progress = false` in later chapters
- drop explicit assignment of `Grouping` contrasts throughout
- add labels to some code blocks making it easier to judge progress when rendering