### PR TITLE
update setup instructions for QuartoNotebookRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,14 @@
 
 The book "Embrace Uncertainty: Fitting Mixed-Effects Models with Julia"
 
-This repository uses [Quarto](https://quarto.org). To be able to render all the pages, you will need an appropriate Jupyter kernel installed and the local environment instantiated.
+This repository uses [Quarto](https://quarto.org) with the Julia code execution supplied by [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/), which requires Quarto 1.5+.
+
+As of early May 2024, Quarto 1.5 is only available as a preview release, which you'll need to [download from GitHub](https://github.com/quarto-dev/quarto-cli/releases). Under each release's "Assets", you can find platform-specific installers.
 
 ```sh
 ~/EmbraceUncertainty$ julia
 
 julia> using Pkg
-
-julia> Pkg.add("IJulia")
-    Updating registry at `~/.julia/registries/General.toml`
-   Resolving package versions...
-< lots of output >
-
-julia> using IJulia
-
-julia> installkernel("julia", "--threads=auto", "--project=@.")
-[ Info: Installing julia kernelspec in ~/.local/share/jupyter/kernels/julia-1.10
-"~/.local/share/jupyter/kernels/julia-1.10"
 
 julia> Pkg.activate(".")
   Activating project at `~/EmbraceUncertainty`
@@ -31,8 +22,4 @@ julia> exit()
 ~/EmbraceUncertainty$ quarto preview
 
 < lots of output >
-
 ```
-
-Note two important parts of the kernel used above: a flag to activate local Julia environment and a flag to allow Julia to automatically set the appropriate number of threads.
-The former is necessary to render the book at all; the latter may improve render speed.


### PR DESCRIPTION
I think some of the confusion in #59 was caused by the outdated install instructions.