### PR TITLE
zizmor audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 28

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,17 +7,22 @@ jobs:
   typos-check:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # reviewdog/action-suggester posts inline PR suggestions
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@52940116a3ef7d561b8e27ca5b90db8c8c73b2b5  # v1.46.0
         # don't fail on typos in files not impacted by this PR
         continue-on-error: true
         with:
             config: _typos.toml
             write_changes: true
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos
           fail_on_error: true

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check spelling
-        uses: crate-ci/typos@52940116a3ef7d561b8e27ca5b90db8c8c73b2b5  # v1.46.0
+        uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274  # v1.46.0
         # don't fail on typos in files not impacted by this PR
         continue-on-error: true
         with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| zizmor.yaml | `zizmor` | none (new file) | `contents: read` | New workflow; reads repo to run audit |
| spellcheck.yml | `typos-check` | none (default) | `contents: read`, `pull-requests: write` | Checks out code; reviewdog posts inline PR suggestions |
